### PR TITLE
[FE/Sprint #2] 카드 결제 로딩 인디케이터 구현

### DIFF
--- a/fe/src/components/Modal/PaymentIndicator.module.css
+++ b/fe/src/components/Modal/PaymentIndicator.module.css
@@ -1,0 +1,92 @@
+.paymentIndicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+}
+
+.paymentIndicator span {
+  color: #e9d78d;
+  font-family: var(--font-family);
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-display);
+}
+
+.indicatorWrap {
+  color: official;
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+.indicatorWrap div {
+  transform-origin: 40px 40px;
+  animation: indicator 1.2s linear infinite;
+}
+.indicatorWrap div:after {
+  content: ' ';
+  display: block;
+  position: absolute;
+  top: 3px;
+  left: 37px;
+  width: 6px;
+  height: 18px;
+  border-radius: 20%;
+  background: #e9d78d;
+}
+.indicatorWrap div:nth-child(1) {
+  transform: rotate(0deg);
+  animation-delay: -1.1s;
+}
+.indicatorWrap div:nth-child(2) {
+  transform: rotate(30deg);
+  animation-delay: -1s;
+}
+.indicatorWrap div:nth-child(3) {
+  transform: rotate(60deg);
+  animation-delay: -0.9s;
+}
+.indicatorWrap div:nth-child(4) {
+  transform: rotate(90deg);
+  animation-delay: -0.8s;
+}
+.indicatorWrap div:nth-child(5) {
+  transform: rotate(120deg);
+  animation-delay: -0.7s;
+}
+.indicatorWrap div:nth-child(6) {
+  transform: rotate(150deg);
+  animation-delay: -0.6s;
+}
+.indicatorWrap div:nth-child(7) {
+  transform: rotate(180deg);
+  animation-delay: -0.5s;
+}
+.indicatorWrap div:nth-child(8) {
+  transform: rotate(210deg);
+  animation-delay: -0.4s;
+}
+.indicatorWrap div:nth-child(9) {
+  transform: rotate(240deg);
+  animation-delay: -0.3s;
+}
+.indicatorWrap div:nth-child(10) {
+  transform: rotate(270deg);
+  animation-delay: -0.2s;
+}
+.indicatorWrap div:nth-child(11) {
+  transform: rotate(300deg);
+  animation-delay: -0.1s;
+}
+.indicatorWrap div:nth-child(12) {
+  transform: rotate(330deg);
+  animation-delay: 0s;
+}
+@keyframes indicator {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}

--- a/fe/src/components/Modal/PaymentIndicator.tsx
+++ b/fe/src/components/Modal/PaymentIndicator.tsx
@@ -1,0 +1,29 @@
+import styles from './PaymentIndicator.module.css';
+
+export function PaymentIndicator() {
+  return (
+    <div className={styles.paymentIndicator}>
+      <Indicator />
+      <span>카드 결제중...</span>
+    </div>
+  );
+}
+
+function Indicator() {
+  return (
+    <div className={styles.indicatorWrap}>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 카드 결제 로딩 인디케이터

### 미리보기
https://github.com/codesquad-gwanaksan/kiosk-max/assets/109706689/712eb3e0-0548-4d3c-b91e-2f1d0999c0f2

### 컴포넌트 리렉토리 위치
fe > src > components > Modal

### 추가 고민
- 카드 결제 로딩 인디케이터가 받아야 될 props는 없는가?